### PR TITLE
Added SearchLambdaCollection utility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,11 +146,6 @@
       <version>1.2.1</version>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-lambda-java-events</artifactId>
-      <version>3.1.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
       <version>${lucene.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.anlessini</groupId>
   <artifactId>anlessini</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <name>Anlessini</name>
   <description>Serverless Anserini</description>
   <url>http://anserini.io/</url>
@@ -32,6 +32,7 @@
   </developers>
 
   <properties>
+    <revision>0.1.0-SNAPSHOT</revision>
     <lucene.version>8.3.0</lucene.version>
     <amazon.aws.sdk.version>1.11.848</amazon.aws.sdk.version>
     <anserini.version>0.9.4</anserini.version>

--- a/search-lambda-function/pom.xml
+++ b/search-lambda-function/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <artifactId>anlessini</artifactId>
     <groupId>io.anlessini</groupId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <build>

--- a/search-lambda-function/src/main/java/io/anlessini/SearchLambda.java
+++ b/search-lambda-function/src/main/java/io/anlessini/SearchLambda.java
@@ -62,7 +62,7 @@ public class SearchLambda implements RequestHandler<SearchRequest, SearchRespons
       }
       SearchResponse response = new SearchResponse(hits);
 
-      LOG.info("Response: " + response);
+      LOG.trace("Response: " + response);
       long endTime = System.currentTimeMillis();
       LOG.info("Query latency: " + (endTime - startTime) + " ms");
 

--- a/search-lambda-function/src/main/java/io/anlessini/SearchLambda.java
+++ b/search-lambda-function/src/main/java/io/anlessini/SearchLambda.java
@@ -1,23 +1,14 @@
 package io.anlessini;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
-import com.amazonaws.services.dynamodbv2.document.DynamoDB;
-import com.amazonaws.services.dynamodbv2.document.Item;
-import com.amazonaws.services.dynamodbv2.document.Table;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.anlessini.store.S3BlockCache;
 import io.anlessini.store.S3Directory;
 import io.anlessini.store.S3IndexInput;
+import io.anserini.index.IndexArgs;
+import io.anserini.search.query.BagOfWordsQueryGenerator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
@@ -25,111 +16,62 @@ import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.*;
 import org.apache.lucene.search.similarities.BM25Similarity;
 import org.apache.lucene.search.similarities.Similarity;
 
 import java.io.*;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
-public class SearchLambda implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+public class SearchLambda implements RequestHandler<SearchRequest, SearchResponse> {
+  public static final Sort BREAK_SCORE_TIES_BY_DOCID =
+      new Sort(SortField.FIELD_SCORE, new SortField(IndexArgs.ID, SortField.Type.STRING_VAL));
   private static final Logger LOG = LogManager.getLogger(SearchLambda.class);
 
+  private final AmazonS3 s3Client;
   private final S3Directory directory;
   private final IndexReader reader;
+  private final Analyzer analyzer;
   private static final String S3_INDEX_BUCKET = System.getenv("INDEX_BUCKET");
   private static final String S3_INDEX_KEY = System.getenv("INDEX_KEY");
-
-  private final DynamoDB dynamoDB;
-  private final String DYNAMODB_TABLE_NAME = System.getenv("TABLE_NAME");
-  private final Table dynamoTable;
-
-  private final AmazonS3 s3Client;
-
-  private static final ObjectMapper objectMapper = new ObjectMapper();
-  private static final ObjectWriter writer = objectMapper.writer();
 
   public SearchLambda() throws IOException {
     s3Client = AmazonS3ClientBuilder.defaultClient();
     directory = new S3Directory(s3Client, S3_INDEX_BUCKET, S3_INDEX_KEY);
     reader = DirectoryReader.open(directory);
-
-    // initializing the dynamodb instance
-    dynamoDB = new DynamoDB(AmazonDynamoDBClientBuilder.defaultClient());
-    dynamoTable = dynamoDB.getTable(DYNAMODB_TABLE_NAME);
+    analyzer = new EnglishAnalyzer();
   }
 
   @Override
-  public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
-    APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent();
-    String queryString = input.getQueryStringParameters().get("query");
-    int maxDocs = Integer.parseInt(input.getQueryStringParameters().getOrDefault("max_docs", "10"));
-
+  public SearchResponse handleRequest(SearchRequest input, Context context) {
     try {
-      String hits = search(queryString, maxDocs);
-      response.setStatusCode(200);
-      response.setBody(hits);
-    } catch (IOException e) {
-      LOG.error(e.getMessage(), e);
-      response.setStatusCode(500);
-      try {
-        response.setBody(writer.writeValueAsString(Map.of("message", e.getMessage())));
-      } catch (JsonProcessingException ex) {
-        LOG.error("Error writing JSON message", ex);
+      LOG.info("Received input: " + input);
+      long startTime = System.currentTimeMillis();
+      Similarity similarity = new BM25Similarity(input.getBm25k1(), input.getBm25b());
+      IndexSearcher searcher = new IndexSearcher(reader);
+      searcher.setSimilarity(similarity);
+      searcher.setQueryCache(null); // disable query caching
+
+      Query query = new BagOfWordsQueryGenerator().buildQuery(IndexArgs.CONTENTS, analyzer, input.getQuery());
+      TopDocs topDocs = searcher.search(query, input.getMaxDocs(), BREAK_SCORE_TIES_BY_DOCID, true);
+
+      List<SearchResponse.Hit> hits = new ArrayList<>();
+      for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+        Document doc = reader.document(scoreDoc.doc);
+        hits.add(new SearchResponse.Hit(doc.get(IndexArgs.ID), scoreDoc.score, scoreDoc.doc));
       }
+      SearchResponse response = new SearchResponse(hits);
+
+      LOG.info("Response: " + response);
+      long endTime = System.currentTimeMillis();
+      LOG.info("Query latency: " + (endTime - startTime) + " ms");
+
+      S3BlockCache.getInstance().logStats(Boolean.parseBoolean(System.getenv("CLEAR_CACHE_STATS")));
+      S3IndexInput.logStats(Boolean.parseBoolean(System.getenv("CLEAR_CACHE_STATS")));
+
+      return response;
+    } catch (IOException ioe) {
+      throw new RuntimeException(ioe);
     }
-
-    response.setHeaders(Map.of(
-        "Content-Type", "application/json",
-        "Access-Control-Allow-Origin", "*"
-    ));
-    return response;
-  }
-
-  public String search(String qstring, int maxDocs) throws IOException {
-    long startTime = System.currentTimeMillis();
-    Analyzer analyzer = new EnglishAnalyzer();
-    Similarity similarity = new BM25Similarity(0.9f, 0.4f);
-    IndexSearcher searcher = new IndexSearcher(reader);
-    searcher.setSimilarity(similarity);
-    searcher.setQueryCache(null);     // disable query caching
-
-    LOG.info("Query: " + qstring);
-    Query query = SearchDemo.buildQuery("contents", analyzer, qstring);
-    TopDocs topDocs = searcher.search(query, maxDocs);
-
-    LOG.info("Number of hits: " + topDocs.scoreDocs.length);
-
-    String[] docids = new String[topDocs.scoreDocs.length];
-    for (int i = 0; i < topDocs.scoreDocs.length; i++) {
-      Document doc;
-      doc = reader.document(topDocs.scoreDocs[i].doc);
-      String docid = doc.getField("id").stringValue();
-      docids[i] = docid;
-    }
-
-    LOG.info("Docids: " + Arrays.toString(docids));
-    S3BlockCache.getInstance().logStats(Boolean.parseBoolean(System.getenv("CLEAR_CACHE_STATS")));
-    S3IndexInput.logStats(Boolean.parseBoolean(System.getenv("CLEAR_CACHE_STATS")));
-
-    ObjectNode rootNode = objectMapper.createObjectNode();
-    rootNode.put("query_id", UUID.randomUUID().toString());
-    ArrayNode response = objectMapper.createArrayNode();
-
-    for (int i = 0; i < topDocs.scoreDocs.length; i++) {
-      // retreiving from dynamodb
-      Item item = dynamoTable.getItem("id", docids[i]);
-      response.add(item.toJSON());
-    }
-    rootNode.set("response", response);
-    // System.out.println(mapper.writeValueAsString(rootNode));
-
-    long endTime = System.currentTimeMillis();
-    LOG.info("Query latency: " + (endTime - startTime) + " ms");
-    return objectMapper.writeValueAsString(rootNode);
   }
 }

--- a/search-lambda-function/src/main/java/io/anlessini/SearchRequest.java
+++ b/search-lambda-function/src/main/java/io/anlessini/SearchRequest.java
@@ -8,11 +8,8 @@ public class SearchRequest implements Serializable, Cloneable {
   static final Float DEFAULT_BM25_B = 0.4f;
 
   private String query;
-
   private Integer maxDocs;
-
   private Float bm25k1;
-
   private Float bm25b;
 
   public SearchRequest() {

--- a/search-lambda-function/src/main/java/io/anlessini/SearchRequest.java
+++ b/search-lambda-function/src/main/java/io/anlessini/SearchRequest.java
@@ -1,0 +1,72 @@
+package io.anlessini;
+
+import java.io.Serializable;
+
+public class SearchRequest implements Serializable, Cloneable {
+  static final Integer DEFAULT_MAX_DOCS = 10;
+  static final Float DEFAULT_BM25_K1 = 0.9f;
+  static final Float DEFAULT_BM25_B = 0.4f;
+
+  private String query;
+
+  private Integer maxDocs;
+
+  private Float bm25k1;
+
+  private Float bm25b;
+
+  public SearchRequest() {
+    setMaxDocs(DEFAULT_MAX_DOCS);
+    setBm25k1(DEFAULT_BM25_K1);
+    setBm25b(DEFAULT_BM25_B);
+  }
+
+  public SearchRequest(String query, Integer maxDocs, Float bm25k1, Float bm25b) {
+    this.query = query;
+    this.maxDocs = maxDocs;
+    this.bm25k1 = bm25k1;
+    this.bm25b = bm25b;
+  }
+
+  public String getQuery() {
+    return query;
+  }
+
+  public void setQuery(String query) {
+    this.query = query;
+  }
+
+  public Integer getMaxDocs() {
+    return maxDocs;
+  }
+
+  public void setMaxDocs(Integer maxDocs) {
+    this.maxDocs = maxDocs;
+  }
+
+  public Float getBm25k1() {
+    return bm25k1;
+  }
+
+  public void setBm25k1(Float bm25k1) {
+    this.bm25k1 = bm25k1;
+  }
+
+  public Float getBm25b() {
+    return bm25b;
+  }
+
+  public void setBm25b(Float bm25b) {
+    this.bm25b = bm25b;
+  }
+
+  @Override
+  public String toString() {
+    return "SearchRequest{" +
+        "query='" + query + '\'' +
+        ", maxDocs=" + maxDocs +
+        ", bm25k1=" + bm25k1 +
+        ", bm25b=" + bm25b +
+        '}';
+  }
+}

--- a/search-lambda-function/src/main/java/io/anlessini/SearchResponse.java
+++ b/search-lambda-function/src/main/java/io/anlessini/SearchResponse.java
@@ -1,0 +1,47 @@
+package io.anlessini;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class SearchResponse implements Serializable, Cloneable {
+  public final List<Hit> hits;
+
+  public SearchResponse(List<Hit> hits) {
+    this.hits = hits;
+  }
+
+  public static class Hit implements Serializable, Cloneable {
+    /** The document identifier field
+     *  @see io.anserini.index.IndexArgs#ID */
+    public final String docid;
+
+    /** The score of this document for the query */
+    public final Float score;
+
+    /** The document's number
+     *  @see org.apache.lucene.search.ScoreDoc#doc */
+    public final Integer doc;
+
+    public Hit(String docid, Float score, Integer doc) {
+      this.docid = docid;
+      this.score = score;
+      this.doc = doc;
+    }
+
+    @Override
+    public String toString() {
+      return "Hit{" +
+          "docid='" + docid + '\'' +
+          ", score=" + score +
+          ", doc=" + doc +
+          '}';
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "SearchResponse{" +
+        "hits=" + hits +
+        '}';
+  }
+}

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -24,6 +24,10 @@
               <mainClass>io.anlessini.utils.ImportCollection</mainClass>
               <id>ImportCollection</id>
             </program>
+            <program>
+              <mainClass>io.anlessini.utils.SearchLambdaCollection</mainClass>
+              <id>SearchLambdaCollection</id>
+            </program>
           </programs>
         </configuration>
         <executions>
@@ -40,24 +44,18 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>2.10.1</version>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-lambda</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.10.1</version>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.6</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
-      <version>2.10.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.10.1</version>
+      <groupId>io.anlessini</groupId>
+      <artifactId>search-lambda-function</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 </project>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <artifactId>anlessini</artifactId>
     <groupId>io.anlessini</groupId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <build>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>io.anlessini</groupId>
       <artifactId>search-lambda-function</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/utils/src/main/java/io/anlessini/utils/SearchLambdaCollection.java
+++ b/utils/src/main/java/io/anlessini/utils/SearchLambdaCollection.java
@@ -1,0 +1,204 @@
+package io.anlessini.utils;
+
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
+import com.amazonaws.services.lambda.model.InvocationType;
+import com.amazonaws.services.lambda.model.InvokeRequest;
+import com.amazonaws.services.lambda.model.InvokeResult;
+import com.google.gson.Gson;
+import io.anlessini.SearchRequest;
+import io.anlessini.SearchResponse;
+import io.anserini.search.topicreader.TopicReader;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.zookeeper.server.ByteBufferInputStream;
+import org.kohsuke.args4j.*;
+import org.kohsuke.args4j.spi.StringArrayOptionHandler;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SearchLambdaCollection<K> {
+  private static final Logger LOG = LogManager.getLogger(SearchLambdaCollection.class);
+
+  public static class Args {
+    // required arguments
+    @Option(name = "-lambda", required = true, usage = "The ARN of the search lambda.")
+    public String lambda;
+
+    @Option(name = "-topics", metaVar = "[file]", handler = StringArrayOptionHandler.class, required = true, usage = "topics file")
+    public String[] topics;
+
+    @Option(name = "-topic.reader", required = true, usage = "TopicReader to use.")
+    public String topicReader;
+
+    @Option(name = "-output", metaVar = "[file]", required = true, usage = "Output run file.")
+    public String output;
+
+    @Option(name = "-threads", metaVar = "[Number]", usage = "Number of Threads")
+    public int threads = 8;
+
+    @Option(name = "-topic.fields", handler = StringArrayOptionHandler.class, usage = "Which field of the query should be used, default \"title\"." +
+        " For TREC ad hoc topics, description or narrative can be used.")
+    public String[] topicFields = new String[]{"title"};
+
+    @Option(name = "-hits", metaVar = "[number]", usage = "max number of hits to return")
+    public int hits = 1000;
+
+    @Option(name = "-bm25.k1", metaVar = "[number]", usage = "BM25: k1 parameter")
+    public float bm25k1 = 0.9f;
+
+    @Option(name = "-bm25.b", metaVar = "[number]", usage = "BM25: b parameter")
+    public float bm25b = 0.4f;
+
+    @Option(name = "-remove.duplicates", usage = "Remove duplicate docids when writing final run output.")
+    public Boolean removeDuplicates = false;
+
+    @Option(name = "-strip.segment.id", usage = "Remove the .XXXXX suffix used to denote different segments from an document")
+    public Boolean stripSegmentId = false;
+
+    @Option(name = "-report.interval", metaVar = "[number]", usage = "The number of queries processed in between report log messages.")
+    public int reportInterval = 200;
+
+    @Option(name = "-runtag", metaVar = "[tag]", usage = "runtag")
+    public String runtag = "anlessini";
+  }
+
+  private final Args args;
+  private final AWSLambda lambda; // thread-safe AWS lambda client
+  private final SortedMap<K, Map<String, String>> topics;
+  private final Gson gson = new Gson();
+
+  @SuppressWarnings("unchecked")
+  public SearchLambdaCollection(Args args) {
+    this.args = args;
+    this.lambda = AWSLambdaClientBuilder.defaultClient();
+    this.topics = new TreeMap<>();
+
+    for (String topicsFile : args.topics) {
+      Path path = Paths.get(topicsFile);
+      if (!Files.exists(path) || !Files.isRegularFile(path) || !Files.isReadable(path)) {
+        throw new IllegalArgumentException("Topics file " + path + " does not exist or is not a (readable) file.");
+      }
+      try {
+        TopicReader<K> tr = (TopicReader<K>) Class.forName("io.anserini.search.topicreader." + args.topicReader + "TopicReader")
+            .getConstructor(Path.class).newInstance(path);
+        this.topics.putAll(tr.read());
+      } catch (Exception e) {
+        throw new IllegalArgumentException("Unable to load topic " + path + " using topic reader " + args.topicReader, e);
+      }
+    }
+  }
+
+  public void runTopics() throws IOException {
+    final long start = System.nanoTime();
+    final AtomicInteger count = new AtomicInteger();
+    PrintWriter out = new PrintWriter(Files.newBufferedWriter(Paths.get(args.output), StandardCharsets.US_ASCII));
+    final ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(args.threads);
+
+    for (final Map.Entry<K, Map<String, String>> topicEntry : topics.entrySet()) {
+      executor.execute(() -> {
+        K qid = topicEntry.getKey();
+
+        StringBuilder sb = new StringBuilder();
+        for (String field : args.topicFields) {
+          sb.append(" ").append(topicEntry.getValue().get(field.trim()));
+        }
+        String queryString = sb.toString();
+
+        SearchRequest request = new SearchRequest(queryString, args.hits, args.bm25k1, args.bm25b);
+        InvokeRequest invokeRequest = new InvokeRequest()
+            .withFunctionName(args.lambda)
+            .withInvocationType(InvocationType.RequestResponse)
+            .withPayload(gson.toJson(request));
+
+        InvokeResult invokeResult = lambda.invoke(invokeRequest);
+        SearchResponse response = gson.fromJson(new InputStreamReader(new ByteBufferInputStream(invokeResult.getPayload())), SearchResponse.class);
+
+        if (invokeResult.getStatusCode() != 200 || response == null || response.hits == null) {
+          String logMessage = invokeResult.getLogResult() != null ? new String(Base64.getDecoder().decode(invokeResult.getLogResult())) : "";
+          LOG.error("Invocation " + request + " received code " + invokeResult.getStatusCode() +
+              ", error: " + invokeResult.getFunctionError() + "\n " + logMessage);
+        }
+
+        Set<String> docids = new HashSet<>();
+        int rank = 1;
+        StringBuilder buf = new StringBuilder();
+        for (SearchResponse.Hit hit : response.hits) {
+          String docid = hit.docid;
+          if (args.stripSegmentId) {
+            docid = docid.split("\\.")[0];
+          }
+
+          if (args.removeDuplicates) {
+            if (docids.contains(docid)) {
+              continue;
+            } else {
+              docids.add(docid);
+            }
+          }
+
+          buf.append(String.format(Locale.US, "%s Q0 %s %d %f %s\n",
+              qid, docid, rank, hit.score, args.runtag));
+
+          rank++;
+        }
+        out.println(buf.toString());
+        int processed = count.incrementAndGet();
+        if (processed % args.reportInterval == 0) {
+          LOG.info(String.format("%d queries processed", processed));
+        }
+      });
+    }
+
+    executor.shutdown();
+
+    try {
+      // Wait for existing tasks to terminate
+      while (!executor.awaitTermination(1, TimeUnit.MINUTES)) {
+        LOG.info(String.format("%d queries processed", count.incrementAndGet()));
+      }
+    } catch (InterruptedException ie) {
+      // (Re-)Cancel if current thread also interrupted
+      executor.shutdownNow();
+      // Preserve interrupt status
+      Thread.currentThread().interrupt();
+    }
+
+    out.flush();
+    out.close();
+    final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+    LOG.info(count.get() + " topics processed in " + DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss"));
+  }
+
+  public static void main(String[] args) throws Exception {
+    Args searchArgs = new Args();
+    CmdLineParser parser = new CmdLineParser(searchArgs, ParserProperties.defaults().withUsageWidth(100));
+
+    try {
+      parser.parseArgument(args);
+    } catch (CmdLineException e) {
+      System.err.println(e.getMessage());
+      parser.printUsage(System.err);
+      System.err.println("Example: SearchLambdaCollection" + parser.printExample(OptionHandlerFilter.REQUIRED));
+      return;
+    }
+
+    final long start = System.nanoTime();
+    SearchLambdaCollection searcher = new SearchLambdaCollection(searchArgs);
+    searcher.runTopics();
+    final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+    LOG.info("Total run time: " + DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss"));
+  }
+}


### PR DESCRIPTION
* Per our discussion in the slack channel, the search lambda now only returns the docids and the QA lambda needs to query from DynamoDB, in order to reduce the total bandwidth usage
* Added SearchLambdaCollection (analogous to SearchCollection in Anserini, but for Lambda)

A test run with [msmarco-passage](https://github.com/castorini/anserini/blob/master/docs/regressions-msmarco-passage.md) gave me a total run time of roughly 9 minutes for 6980 queries on a EC2 machine in the same region. For comparison, the same search takes about 5 minutes on my personal machine (8-core Intel Core i9). The delay/duration metric collected by Lambda is shown below. TL;DR, most queries (p95) finishes under a second, and the average is generally around half a second.

![image](https://user-images.githubusercontent.com/14900215/98467172-ed3cbf80-220e-11eb-9a3c-b04b1822f67c.png)


@lintool @shaneding 