### PR TITLE
Added QA prototype

### DIFF
--- a/anlessini-qa/.gitignore
+++ b/anlessini-qa/.gitignore
@@ -1,0 +1,1 @@
+mobilebert-uncased-finetuned-squadv2/

--- a/anlessini-qa/Dockerfile
+++ b/anlessini-qa/Dockerfile
@@ -1,0 +1,10 @@
+FROM public.ecr.aws/lambda/python:3.6
+
+RUN python3.6 -m pip install --no-cache-dir -t . \
+    torch==1.5.0+cpu transformers \
+    -f https://download.pytorch.org/whl/torch_stable.html
+
+COPY app.py mobilebert-uncased-finetuned-squadv2 ./
+
+# Command can be overwritten by providing a different command in the template directly.
+CMD ["app.lambda_handler"]

--- a/anlessini-qa/app.py
+++ b/anlessini-qa/app.py
@@ -1,0 +1,18 @@
+import torch
+from transformers import pipeline
+import json 
+
+def lambda_handler(event, context):
+    QnA_pipeline = pipeline('question-answering', model='.')
+    #body = json.loads(event)
+    result = QnA_pipeline({
+        'context': event['queryStringParameters']['context'],
+        'question': event['queryStringParameters']['question']
+    })
+    return {
+        "statusCode": 200,
+        "body": json.dumps({'result': result}),
+        "headers": {
+            'Content-Type': 'text/html',
+        }
+    }


### PR DESCRIPTION
AWS recently added [support ](https://aws.amazon.com/blogs/aws/new-for-aws-lambda-container-image-support/)for custom container images for lambda (best timing ever :P). I made a prototype lambda function which takes in a question/context, and scores it. This will likely need to be changed later. @adamyy does this fit in with the architecture diagram you had before? Is it possible to just add this to the python lambda function you wrote in #23?