### PR TITLE
Clean up stats logging to reduce computation in the function handler

### DIFF
--- a/search-lambda-function/src/main/java/io/anlessini/SearchLambda.java
+++ b/search-lambda-function/src/main/java/io/anlessini/SearchLambda.java
@@ -66,8 +66,12 @@ public class SearchLambda implements RequestHandler<SearchRequest, SearchRespons
       long endTime = System.currentTimeMillis();
       LOG.info("Query latency: " + (endTime - startTime) + " ms");
 
-      S3BlockCache.getInstance().logStats(Boolean.parseBoolean(System.getenv("CLEAR_CACHE_STATS")));
-      S3IndexInput.logStats(Boolean.parseBoolean(System.getenv("CLEAR_CACHE_STATS")));
+      S3BlockCache.getInstance().logStats();
+      S3IndexInput.logStats();
+      if (Boolean.parseBoolean(System.getenv("CLEAR_CACHE_STATS"))) {
+        S3BlockCache.getInstance().clearStats();
+        S3IndexInput.clearStats();
+      }
 
       return response;
     } catch (IOException ioe) {

--- a/search-lambda-function/src/main/java/io/anlessini/store/S3BlockCache.java
+++ b/search-lambda-function/src/main/java/io/anlessini/store/S3BlockCache.java
@@ -1,6 +1,5 @@
 package io.anlessini.store;
 
-import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AtomicLongMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -131,7 +130,9 @@ public class S3BlockCache {
     return cb.data;
   }
 
-  public void logStats(boolean clearStats) {
+  public void logStats() {
+    if (!LOG.isTraceEnabled()) return;
+
     Set<String> fileKeys = new HashSet<>();
     fileKeys.addAll(hitCount.asMap().keySet());
     fileKeys.addAll(missCount.asMap().keySet());
@@ -143,12 +144,12 @@ public class S3BlockCache {
       LOG.trace(String.format("%-20s %,10d %,10d %,10d", key, hitCount.get(key), missCount.get(key), evictCount.get(key)));
     });
     LOG.trace("Total cache size=" + size.get() + ", elements=" + elements.get());
+  }
 
-    if (clearStats) {
-      hitCount.putAll(Maps.transformValues(hitCount.asMap(), input -> 0L));
-      missCount.putAll(Maps.transformValues(missCount.asMap(), input -> 0L));
-      evictCount.putAll(Maps.transformValues(evictCount.asMap(), input -> 0L));
-    }
+  public void clearStats() {
+    hitCount.clear();
+    missCount.clear();
+    evictCount.clear();
   }
 
   public static class CacheBlob {

--- a/search-lambda-function/src/main/java/io/anlessini/store/S3IndexInput.java
+++ b/search-lambda-function/src/main/java/io/anlessini/store/S3IndexInput.java
@@ -168,12 +168,13 @@ public class S3IndexInput extends BufferedIndexInput {
     }
   }
 
-  public static void logStats(boolean clearStats) {
+  public static void logStats() {
     LOG.trace("Total bytes read from S3: " + stats.readFromS3.get()
         + ", total bytes read: " + stats.readTotal.get());
-    if (clearStats) {
-      stats.readTotal.set(0);
-      stats.readFromS3.set(0);
-    }
+  }
+
+  public static void clearStats() {
+    stats.readTotal.set(0);
+    stats.readFromS3.set(0);
   }
 }


### PR DESCRIPTION
* Since logging is only done for debug purposes, checking if debug is enabled prior to computing the stats can reduce the amount of computation in the function handler code
* This PR has no functional change

Tested with CORD-19 corpus and everything seems normal, going to self-merge :smile: